### PR TITLE
Fix "How to build and run" instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ mkdir stylit/bin
 cd stylit/bin
 cmake ..
 make
-cd ../
 ./run_tests "Experiments"
 ```
 


### PR DESCRIPTION
`run_tests` executable is located in `bin/` subfolder